### PR TITLE
Feat/1150 i18n publiccode yaml

### DIFF
--- a/client/src/components/SoftwareCard.astro
+++ b/client/src/components/SoftwareCard.astro
@@ -4,13 +4,15 @@ import { getYear } from "date-fns";
 import GithubLogo from "./GithubLogo.astro";
 import LinkButton from "./LinkButton.astro";
 import { getRelativeLocaleUrl } from 'astro:i18n';
-import { type Lang, useTranslations } from "../i18n/utils";
+import { type Lang, resolveLanguage, useTranslations } from "../i18n/utils";
 
 const { software } = Astro.props;
 const content = yaml.load(software.publiccodeYml);
 const lang = Astro.currentLocale as Lang;
 const t = useTranslations(lang);
 const detailPageUrl = getRelativeLocaleUrl(lang, "softwares/" + software.id);
+const availableLanguages = Object.keys(content.description);
+const description = content.description[resolveLanguage(lang, availableLanguages)];
 ---
 
 <style>
@@ -42,7 +44,7 @@ const detailPageUrl = getRelativeLocaleUrl(lang, "softwares/" + software.id);
         <h2>{content.name}</h2>
       </div>
       <p>
-        {content.description.en?.shortDescription}
+        {description?.shortDescription}
       </p>
     </div>
     <section class="card__content-icons">

--- a/client/src/components/SoftwareCard.astro
+++ b/client/src/components/SoftwareCard.astro
@@ -39,7 +39,7 @@ const detailPageUrl = getRelativeLocaleUrl(lang, "softwares/" + software.id);
         }
       </p>
       <div class="card__title">
-        <h3>{content.name}</h3>
+        <h2>{content.name}</h2>
       </div>
       <p>
         {content.description.en?.shortDescription}

--- a/client/src/components/SoftwareDetail.astro
+++ b/client/src/components/SoftwareDetail.astro
@@ -1,8 +1,12 @@
 ---
 import yaml from "js-yaml";
+import  { type Lang, resolveLanguage } from "../i18n/utils";
 
 const { software } = Astro.props;
 const content = yaml.load(software.publiccodeYml);
+const lang = Astro.currentLocale as Lang
+const availableLanguages = Object.keys(content.description);
+const description = content.description[resolveLanguage(lang, availableLanguages)];
 ---
 
 <div>
@@ -17,11 +21,11 @@ const content = yaml.load(software.publiccodeYml);
     </div>
   </div><div class="info-block border-t">
     <h2 class="info-block__title">Short description</h2><div>
-      <div>{content.description?.en?.shortDescription}</div>
+      <div>{description?.shortDescription}</div>
     </div>
   </div><div class="info-block border-t">
     <h2 class="info-block__title">Documentation</h2><div>
-      <div>{content.description?.en?.longDescription}</div>
+      <div>{description?.longDescription}</div>
     </div>
   </div><div class="info-block border-t">
     <h2 class="info-block__title">Software version</h2><div>

--- a/client/src/components/SoftwareDetail.astro
+++ b/client/src/components/SoftwareDetail.astro
@@ -7,28 +7,28 @@ const content = yaml.load(software.publiccodeYml);
 
 <div>
   <div class="info-block border-t">
-    <h3 class="info-block__title">Software name</h3>
+    <h2 class="info-block__title">Software name</h2>
     <div>
       <span>{content.name}</span>
     </div>
   </div><div class="info-block border-t">
-    <h3 class="info-block__title">Landing page</h3><div>
+    <h2 class="info-block__title">Landing page</h2><div>
       <div>{content.landingURL}</div>
     </div>
   </div><div class="info-block border-t">
-    <h3 class="info-block__title">Short description</h3><div>
+    <h2 class="info-block__title">Short description</h2><div>
       <div>{content.description?.en?.shortDescription}</div>
     </div>
   </div><div class="info-block border-t">
-    <h3 class="info-block__title">Documentation</h3><div>
+    <h2 class="info-block__title">Documentation</h2><div>
       <div>{content.description?.en?.longDescription}</div>
     </div>
   </div><div class="info-block border-t">
-    <h3 class="info-block__title">Software version</h3><div>
+    <h2 class="info-block__title">Software version</h2><div>
       {content.softwareVersion}
     </div>
   </div><div class="info-block border-t">
-    <h3 class="info-block__title">License</h3><div>
+    <h2 class="info-block__title">License</h2><div>
       <div>{content.legal.license}</div>
     </div>
   </div>

--- a/client/src/i18n/utils.ts
+++ b/client/src/i18n/utils.ts
@@ -17,3 +17,9 @@ export function getLocalePaths(url: URL) {
     };
   });
 }
+
+export function resolveLanguage(lang: Lang, availableLanguages: string[]) {
+  return availableLanguages.find(l => l.startsWith(lang)) ??
+    availableLanguages.find(l => l.startsWith(defaultLang)) ??
+    availableLanguages[0];
+}

--- a/client/src/pages/en/index.astro
+++ b/client/src/pages/en/index.astro
@@ -13,7 +13,7 @@ const t = useTranslations(Astro.currentLocale as Lang);
 <Layout>
   <section class="section bg--secondary-50">
     <div class="container">
-      <h2 class="section__title">{t('index.title')}</h2>
+      <h1 class="section__title">{t('index.title')}</h1>
     </div>
   </section>
   <section class="container section--default">

--- a/client/src/pages/en/softwares/[id].astro
+++ b/client/src/pages/en/softwares/[id].astro
@@ -54,7 +54,7 @@ const homeUrl = getRelativeLocaleUrl(lang);
     >
   </div>
   <div class="container vertical-spacing">
-    <h2 class="h2">{t('software.title')}</h2>
+    <h1 class="h2">{t('software.title')}</h1>
     <SoftwareDetail software={software} />
   </div>
 </Layout>

--- a/client/src/pages/en/softwares/[id].astro
+++ b/client/src/pages/en/softwares/[id].astro
@@ -11,7 +11,7 @@ export async function getStaticPaths() {
   const apiBaseUrl = import.meta.env.API_BASEURL || "http://localhost:3000/v1";
 
   console.log("apiBaseUrl in getStaticPaths", apiBaseUrl)
-  const response = await fetch(`${apiBaseUrl}/software`);
+  const response = await fetch(`${apiBaseUrl}/software?page[size]=10000`);
   const data = await response.json();
   const softwares = data.data;
 


### PR DESCRIPTION
Show the public code description in the selected language if possible. Otherwise in the default language (englisch) or in the first language found.

Additional fixes:
- Fixed a11y problem: "Page should contain a level-one heading"
- Load all softwares, not just the first 25